### PR TITLE
build: hard-link dependencies

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,6 +3,7 @@ lockfileVersion: '9.0'
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
+  injectWorkspacePackages: true
 
 importers:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,5 @@ packages:
 
 onlyBuiltDependencies:
   - esbuild
+
+injectWorkspacePackages: true


### PR DESCRIPTION
Enable hard-linking of dependencies to support `pnpm deploy` command.